### PR TITLE
Bug Fix: change readme to fix TypeError in make_executable_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mutation.set_field('verifyToken', resolve_verify)
 mutation.set_field('refreshToken', resolve_refresh)
 mutation.set_field('tokenAuth', resolve_token_auth)
 
-schema = ariadne.make_executable_schema([type_defs, jwt_schema], [mutation, GenericScalar])
+schema = ariadne.make_executable_schema([type_defs, jwt_schema], mutation, GenericScalar)
 ~~~
 
 


### PR DESCRIPTION
The README instructions caused ariadne to return a TypeError when the *bindables were entered as a list with other bindables. Removing the square brackets and allowing these to be entered as the *args fixes the issue.

![image](https://user-images.githubusercontent.com/39353605/90942496-e8fcc500-e3ca-11ea-8f23-338e62fe25ac.png)
