### PR TITLE
Add support for PyJWT 2.0.0

### DIFF
--- a/ariadne_jwt/utils.py
+++ b/ariadne_jwt/utils.py
@@ -34,11 +34,16 @@ def jwt_payload(user, context=None):
 
 
 def jwt_encode(payload, context=None):
-    return jwt.encode(
+    token = jwt.encode(
         payload,
         jwt_settings.JWT_SECRET_KEY,
         jwt_settings.JWT_ALGORITHM
-    ).decode('utf-8')
+    )
+
+    # As of v2.0.0, PyJWT tokens are returned as string instead of a byte string
+    if isinstance(token, bytes):
+        return token.decode('utf-8')
+    return token
 
 
 def jwt_decode(token, context=None):


### PR DESCRIPTION
As of v2.0.0, PyJWT tokens are returned as string instead of a byte string (see jpadilla/pyjwt#529). This PR adds support for PyJWT 2.0.0.