### PR TITLE
Further improve compatibility with PyJWT 2.0.0

### DIFF
--- a/ariadne_jwt/utils.py
+++ b/ariadne_jwt/utils.py
@@ -69,7 +69,6 @@ def get_authorization_header(request):
 
 
 def get_payload(token, context=None):
-    ExpiredSignatureError = jwt.ExpiredSignatureError if 'ExpiredSignatureError' in dir(jwt.exceptions) else jwt.ExpiredSignature
     try:
         payload = jwt_settings.JWT_DECODE_HANDLER(token, context)
     except ExpiredSignatureError:

--- a/ariadne_jwt/utils.py
+++ b/ariadne_jwt/utils.py
@@ -50,7 +50,6 @@ def jwt_decode(token, context=None):
     return jwt.decode(
         token,
         jwt_settings.JWT_SECRET_KEY,
-        jwt_settings.JWT_VERIFY,
         options={
             'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION
         },

--- a/ariadne_jwt/utils.py
+++ b/ariadne_jwt/utils.py
@@ -70,9 +70,10 @@ def get_authorization_header(request):
 
 
 def get_payload(token, context=None):
+    ExpiredSignatureError = jwt.ExpiredSignatureError if 'ExpiredSignatureError' in dir(jwt.exceptions) else jwt.ExpiredSignature
     try:
         payload = jwt_settings.JWT_DECODE_HANDLER(token, context)
-    except jwt.ExpiredSignature:
+    except ExpiredSignatureError:
         raise exceptions.JSONWebTokenExpired()
     except jwt.DecodeError:
         raise exceptions.JSONWebTokenError(_('Error decoding signature'))


### PR DESCRIPTION
This PR fixes two possible errors caused by breaking changes in PyJWT 2.0.0: 
- AttributeError: module 'jwt' has no attribute 'ExpiredSignature'" (cause: exception was renamed)
- TypeError: decode() got multiple values for argument 'algorithms' (cause: argument was dropped)
