### PR TITLE
Fix Importing deprecated translation imports in django 4.0

### DIFF
--- a/ariadne_jwt/decorators.py
+++ b/ariadne_jwt/decorators.py
@@ -2,7 +2,11 @@ from functools import wraps
 
 import six
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
+
 from graphql import GraphQLResolveInfo
 
 from promise import Promise, is_thenable

--- a/ariadne_jwt/exceptions.py
+++ b/ariadne_jwt/exceptions.py
@@ -1,4 +1,7 @@
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 
 class JSONWebTokenError(Exception):

--- a/ariadne_jwt/mutations.py
+++ b/ariadne_jwt/mutations.py
@@ -1,4 +1,7 @@
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from . import exceptions
 from .settings import jwt_settings

--- a/ariadne_jwt/refresh_token/admin/__init__.py
+++ b/ariadne_jwt/refresh_token/admin/__init__.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from . import filters
 from .. import models

--- a/ariadne_jwt/refresh_token/admin/filters.py
+++ b/ariadne_jwt/refresh_token/admin/filters.py
@@ -1,5 +1,8 @@
 from django.contrib.admin import SimpleListFilter
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'ExpiredFilter',

--- a/ariadne_jwt/refresh_token/apps.py
+++ b/ariadne_jwt/refresh_token/apps.py
@@ -1,5 +1,8 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 
 class RefreshTokenConfig(AppConfig):

--- a/ariadne_jwt/refresh_token/models.py
+++ b/ariadne_jwt/refresh_token/models.py
@@ -5,7 +5,10 @@ from calendar import timegm
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from . import managers, signals
 from ..settings import jwt_settings

--- a/ariadne_jwt/refresh_token/mutations.py
+++ b/ariadne_jwt/refresh_token/mutations.py
@@ -1,6 +1,9 @@
 from calendar import timegm
 
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 from .. import exceptions
 from ..settings import jwt_settings

--- a/ariadne_jwt/refresh_token/shortcuts.py
+++ b/ariadne_jwt/refresh_token/shortcuts.py
@@ -1,5 +1,8 @@
 from django.apps import apps
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 from ..exceptions import JSONWebTokenError
 from ..settings import jwt_settings

--- a/ariadne_jwt/utils.py
+++ b/ariadne_jwt/utils.py
@@ -4,7 +4,10 @@ from calendar import timegm
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 from .settings import jwt_settings
 from . import exceptions


### PR DESCRIPTION
`ugettext` and `ugettext_lazy` imports are deprecated in Django 4.0. This commit will import `ugettext/ugettext_lazy` on ImportError