### PR TITLE
Removed the 'providing_args' argument, according to the Django 3.1 docu…

### DIFF
--- a/ariadne_jwt/refresh_token/signals.py
+++ b/ariadne_jwt/refresh_token/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-refresh_token_revoked = Signal(providing_args=['refresh_token'])
-refresh_token_rotated = Signal(providing_args=['refresh_token'])
+refresh_token_revoked = Signal()
+refresh_token_rotated = Signal()


### PR DESCRIPTION
The "providing_args" argument for Signal has been deprecated in Djago 3.1.

[Django documentation refference:](https://docs.djangoproject.com/en/4.0/releases/3.1/#backwards-incompatible-3-1)

Kudos to @vilarneto for opening the issue regarding this problem.